### PR TITLE
RotEnc now working in both orientations

### DIFF
--- a/Software/PaddleFirmware/Main/Main.ino
+++ b/Software/PaddleFirmware/Main/Main.ino
@@ -216,8 +216,22 @@ void loop()
     prev_rot_button = curr_rot_button;
     
     /* Sample Rotary Encoder Twist Knob */
-    curr_enc_reading = rotEnc.read();
-    constrained_enc_reading = constrain(curr_enc_reading, ROT_ENC_MIN, ROT_ENC_MAX);
+    if (!is_lefty_flipped)
+    {
+      curr_enc_reading =  prev_enc_reading + (-1 * (rotEnc.read() - prev_enc_reading));
+      constrained_enc_reading = constrain(curr_enc_reading, ROT_ENC_MIN, ROT_ENC_MAX);
+      rotEnc.write(constrained_enc_reading);
+    }
+    else
+    {
+      curr_enc_reading = rotEnc.read();
+      constrained_enc_reading = constrain(curr_enc_reading, ROT_ENC_MIN, ROT_ENC_MAX);
+      if (constrained_enc_reading != curr_enc_reading)
+      {
+        rotEnc.write(constrained_enc_reading);
+      }
+    }
+    
     
     if (constrained_enc_reading != prev_enc_reading)
     {

--- a/Software/PaddleFirmware/Main/RotaryEncoder.h
+++ b/Software/PaddleFirmware/Main/RotaryEncoder.h
@@ -12,7 +12,7 @@
 
 #include "Arduino.h"
 
-#define ROT_ENC_MAX 255
+#define ROT_ENC_MAX 127
 #define ROT_ENC_MIN 0
 
 


### PR DESCRIPTION
It's kind of nasty to write() the encoder's value all the time in LH mode, but still appears to be worth it to keep the TeensyDuino Encoder lib.

Also set the RotaryEncoder limits to be actually correct for MIDI ctrl messages

Resolves #3 