### PR TITLE
BUGFIX: Fixed bug in configCLI code

### DIFF
--- a/Software/PaddleFirmware/Main/ConfigConsole.cpp
+++ b/Software/PaddleFirmware/Main/ConfigConsole.cpp
@@ -125,7 +125,8 @@ bool selectColorHandler(Commander &Cmdr)
     Cmdr.println("ERROR: only accepted values are \"BLUE\", \"CYAN\", \"GREEN\", \"PURPLE\", \"RED\",  \"YELLOW\", \"WHITE\"!");
     return false;  
   }
-  
+
+  current_config = loadConfigFromEEPROM(config_state);
   Cmdr.print("SUCCESS: Changed current config to ");
   Cmdr.println(color_str_array[(int) config_state]);
   return true;
@@ -357,19 +358,11 @@ bool ctrlChanHandler(Commander &Cmdr)
   return true;
 }
 
-bool saveColorHandler(Commander &Cmdr)
-{
-  saveConfigToEEPROM(current_config, config_state);
-  const char *color_str = color_str_array[(int) config_state];
-  Cmdr.println("SUCCESS: Saved color handler");
-  return true;
-}
-
 bool exitHandler(Commander &Cmdr)
 {
   Cmdr.println("Saving settings!");
   Cmdr.println("Going down for reboot now!");
-  delay(5000);
+  delay(1000);
   WriteConfigMode(false);
   softRestart();
   

--- a/Software/PaddleFirmware/Main/ConfigConsole.h
+++ b/Software/PaddleFirmware/Main/ConfigConsole.h
@@ -80,11 +80,6 @@ bool button3Handler(Commander &Cmdr);
 bool selectColorHandler (Commander &Cmdr);
 
 /**
- * Save the current config to EEPROM
- */
-bool saveColorHandler(Commander &Cmdr);
-
-/**
  * Enable or disable the current config
  */
 bool colorEnableHandler(Commander &Cmdr);
@@ -119,7 +114,7 @@ const commandList_t masterCommands[] = {
   {"all_config", printConfigHandler, "print all stored configuration, format is `all_config`"},
   {"enable",     colorEnableHandler,  "enable or disable this color, format is `enable=TRUE`"},
   {"color",      selectColorHandler, "select current config color, format is `color=CYAN`"},
-  {"root_note",       rootNoteHandler,    "set root note of scale, format is `root=A`"},
+  {"root_note",  rootNoteHandler,    "set root note of scale, format is `root=A`"},
   {"mode",       modifierHandler,    "set mode, format is `mode=MAJOR`"},
   {"offset1",    button1Handler,     "set button1 offset for this color, format is `offset1=3`"},
   {"offset2",    button2Handler,     "set button2 offset for this color, format is `offset2=5`"},

--- a/Software/PaddleFirmware/Main/Main.ino
+++ b/Software/PaddleFirmware/Main/Main.ino
@@ -130,11 +130,10 @@ void setup()
     Serial.begin(9600);
     while (!Serial)
     {
-        if (PollForSerial(flip_time, is_green_not_yellow))
-        {
-          is_green_not_yellow = !is_green_not_yellow;
-          flip_time = millis() + 500;
-        }
+      if (PollForSerial(flip_time, is_green_not_yellow))
+      {
+        is_green_not_yellow = !is_green_not_yellow;
+        flip_time = millis() + 500;
       }
     }
     printBanner();
@@ -395,8 +394,8 @@ void printBanner(void)
  */
 void printLoopDebugInfo()
 {
-  DEBUG_PRINT("\rLoop Time: ");
-  DEBUG_PRINT(loop_micros);
+  DEBUG_PRINT("\rFret reading: ");
+  DEBUG_PRINT(analogRead(TEENSY_LIN_POT_PIN));
   DEBUG_PRINT(", volume: ");
   DEBUG_PRINT(analog_volume);
   DEBUG_PRINT("     ");

--- a/Software/PaddleFirmware/Main/NonVolatile.h
+++ b/Software/PaddleFirmware/Main/NonVolatile.h
@@ -67,12 +67,12 @@ enum modifier_t
 typedef struct 
 {
   bool is_enabled;
-  int root_note;
+  uint8_t root_note;
   modifier_t modifier;
-  int button1_offset;
-  int button2_offset;
-  int button3_offset;
-  int control_channel;
+  uint8_t button1_offset;
+  uint8_t button2_offset;
+  uint8_t button3_offset;
+  uint8_t control_channel;
 } config_t;
 
 /**

--- a/Software/PaddleFirmware/Main/Version.h
+++ b/Software/PaddleFirmware/Main/Version.h
@@ -13,9 +13,9 @@
 /**
  * Set these to set the SW version
  */
-#define VERSION_MAJOR  (uint8_t) 0
-#define VERSION_MINOR  (uint8_t) 99
-#define VERSION_BUGFIX (uint8_t) 2
+#define VERSION_MAJOR  (uint8_t) 1
+#define VERSION_MINOR  (uint8_t) 0
+#define VERSION_BUGFIX (uint8_t) 0
 
 typedef struct {
   uint8_t version_major;


### PR DESCRIPTION
Resolves #22 

When we were changing the color of the config, we were not also loading the config- this resulted in a sort of "stamping effect" when changing between colors that had different configs. This should be the last issue with EEPROM saved settings.

Also:
* Bumped version to 1.0.0 !!!
* Fixed syntax issue with PollForSerial when #debug was defined
* Removed OBE saveColorHandler callback command (every setting effectively does this now).