### PR TITLE
Implement Multi-Octave configuration

### DIFF
--- a/Software/ClientApp/src/main/python/gui_elements/protocol/PoTProtocol.py
+++ b/Software/ClientApp/src/main/python/gui_elements/protocol/PoTProtocol.py
@@ -14,18 +14,27 @@ modeDict = {
 }
 
 rootNoteDict = {
-    "C": 24,
-    "C#": 25,
-    "D": 26,
-    "D#": 27,
-    "E": 28,
-    "F": 29,
-    "F#": 30,
-    "G": 31,
-    "G#": 32,
-    "A": 33,
-    "A#": 34,
-    "B": 35,
+    "C": 0,
+    "C#": 1,
+    "D": 2,
+    "D#": 3,
+    "E": 4,
+    "F": 5,
+    "F#": 6,
+    "G": 7,
+    "G#": 8,
+    "A": 9,
+    "A#": 10,
+    "B": 11,
+}
+
+octaveDict = {
+    "-1": 0,
+    "0": 12,
+    "1": 24,
+    "2": 36,
+    "3": 48,
+    "4": 60,
 }
 
 
@@ -42,6 +51,7 @@ class PoTProtocol(Protocol):
         self.parameters = {
             "enable": GUIParameter(),
             "root_note": GUIParameter(),
+            "octave": GUIParameter(),
             "mode": GUIParameter(),
             "offset1": GUIParameter(),
             "offset2": GUIParameter(),
@@ -59,6 +69,11 @@ class PoTProtocol(Protocol):
         self.parameters["root_note"].permission = "RW"
         self.parameters["root_note"].param_type = "U8"
         self.parameters["root_note"].description = "Which note is the root note"
+
+        self.parameters["octave"].name = "octave"
+        self.parameters["octave"].permission = "RW"
+        self.parameters["octave"].param_type = "U8"
+        self.parameters["octave"].description = "Which octave is the root for the instrument"
 
         self.parameters["mode"].name = "mode"
         self.parameters["mode"].permission = "RW"
@@ -105,12 +120,13 @@ class PoTProtocol(Protocol):
         self.parameters["offset3"].value_min = 0
         self.parameters["offset3"].value_max = 60
 
-    def set_parameters(self, enable, root_note, mode, offset1, offset2, offset3, control):
+    def set_parameters(self, enable, root_note, mode, offset1, offset2, offset3, control, octave):
         """ use function args to set params """
         self.parameters["offset1"].variable.value = offset1
         self.parameters["offset2"].variable.value = offset2
         self.parameters["mode"].variable.value = mode
         self.parameters["enable"].variable.value = enable
+        self.parameters["octave"].variable.value = octave
         self.parameters["root_note"].variable.value = root_note
         self.parameters["offset3"].variable.value = offset3
         self.parameters["control"].variable.value = control

--- a/Software/ClientApp/src/main/python/gui_elements/tabs/ColorConfig.py
+++ b/Software/ClientApp/src/main/python/gui_elements/tabs/ColorConfig.py
@@ -3,7 +3,7 @@ import json
 from PyQt5.QtCore import pyqtSlot
 
 from pyqtsa.PyQtSA import *
-from gui_elements.protocol.PoTProtocol import modeDict, rootNoteDict
+from gui_elements.protocol.PoTProtocol import modeDict, rootNoteDict, octaveDict
 from serialInterpreter import CMD_EXIT, CMD_RESTORE_DEFAULTS
 
 
@@ -218,6 +218,14 @@ class WidgetNoteAndMode(QSAWidgetCluster):
         super().__init__(master=master,
                          text=text,
                          widgets=[
+                             PoTComboBox(
+                                 master=master,
+                                 text="Octave: ",
+                                 parameter=protocol.parameters["octave"],
+                                 keys=octaveDict.keys(),
+                                 values=octaveDict.values(),
+                                 color=color
+                             ),
                              PoTComboBox(
                                  master=master,
                                  text="Root: ",

--- a/Software/ClientApp/src/main/python/serialInterpreter.py
+++ b/Software/ClientApp/src/main/python/serialInterpreter.py
@@ -123,6 +123,7 @@ class SerialInterpreter:
                 offset1=this_config["offset1"],
                 offset2=this_config["offset2"],
                 offset3=this_config["offset3"],
+                octave=this_config["octave"],
                 root_note=this_config["root_note"] - rootNoteDict["C"],
                 mode=modeDict[this_config["mode"]],
                 enable=1 if this_config["enable"] == "True" else 0

--- a/Software/ClientApp/src/main/resources/base/config/midi_control_codes.json
+++ b/Software/ClientApp/src/main/resources/base/config/midi_control_codes.json
@@ -71,7 +71,7 @@
   "69": "Hold 2",
   "70": "Sound Controller 1 (default: Sound Variation)",
   "71": "Sound Controller 2 (default: Timbre/Harmonic Content)",
-  "72": "Sound Controll 1er 3 (default: Release Time)",
+  "72": "Sound Controller 3 (default: Release Time)",
   "73": "Sound Controller 4 (default: Attack Time)",
   "74": "Sound Controller 5 (default: Brightness)",
   "75": "Sound Controllers 6 (no default)",

--- a/Software/PaddleFirmware/Main/CapTouch.cpp
+++ b/Software/PaddleFirmware/Main/CapTouch.cpp
@@ -46,27 +46,27 @@ static int getScaledNote(int fret, cap_touch_id id, bool is_lefty_flipped, confi
   
   if (in_config.modifier == MOD_MAJOR)
   {
-    return in_config.root_note + MAJOR_DELTAS[delta];
+    return in_config.octave + in_config.root_note + MAJOR_DELTAS[delta];
   }
   else if (in_config.modifier == MOD_MINOR)
   {
-    return in_config.root_note + MINOR_DELTAS[delta];
+    return in_config.octave + in_config.root_note + MINOR_DELTAS[delta];
   }
   else if (in_config.modifier == MOD_MIXOLYDIAN)
   {
-    return in_config.root_note + MIXOLYDIAN_DELTAS[delta];
+    return in_config.octave + in_config.root_note + MIXOLYDIAN_DELTAS[delta];
   }
   else if (in_config.modifier == MOD_DORIAN)
   {
-    return in_config.root_note + DORIAN_DELTAS[delta];
+    return in_config.octave + in_config.root_note + DORIAN_DELTAS[delta];
   }
   else if (in_config.modifier == MOD_CHROMATIC)
   {
-    return in_config.root_note + CHROMATIC_DELTAS[delta];
+    return in_config.octave + in_config.root_note + CHROMATIC_DELTAS[delta];
   }
   else 
   {  
-    return in_config.root_note;
+    return in_config.octave + in_config.root_note;
   }
 }
 

--- a/Software/PaddleFirmware/Main/ConfigConsole.cpp
+++ b/Software/PaddleFirmware/Main/ConfigConsole.cpp
@@ -251,10 +251,29 @@ bool rootNoteHandler(Commander &Cmdr)
   return true;
 }
 
+bool octaveHandler(Commander &Cmdr)
+{
+  if (Cmdr.getInt(myInt))
+  {
+
+    if ((myInt > 60) ||
+    ((myInt % 12 > 0) && (myInt > 0)))
+    {
+      Cmdr.println("ERROR: only accepted values are \"0\", \"12\", \"24\", \"36\", \"48\", \"60\"!");
+      return false;  
+    }
+    
+    Cmdr.print("SUCCESS: Setting octave to ");
+    Cmdr.println(myInt);
+    current_config.octave = myInt;
+    saveConfigToEEPROM(current_config, config_state);
+  }
+  return true;
+}
+
 bool modifierHandler(Commander &Cmdr)
 {
   String compare = NULL;
-  const char *color_str = color_str_array[(int) config_state];
   
   if (!Cmdr.hasPayload())
   {
@@ -310,7 +329,6 @@ bool button1Handler(Commander &Cmdr)
 {
   if (Cmdr.getInt(myInt))
   {
-    const char *color_str = color_str_array[(int) config_state];
     Cmdr.print("SUCCESS: Setting button 1 offset to ");
     Cmdr.println(myInt);
     current_config.button1_offset = myInt;
@@ -323,7 +341,6 @@ bool button2Handler(Commander &Cmdr)
 {
   if (Cmdr.getInt(myInt))
   {
-    const char *color_str = color_str_array[(int) config_state];
     Cmdr.print("SUCCESS: Setting button 2 offset to ");
     Cmdr.println(myInt);
     current_config.button2_offset = myInt;
@@ -336,7 +353,6 @@ bool button3Handler(Commander &Cmdr)
 {
   if (Cmdr.getInt(myInt))
   {
-    const char *color_str = color_str_array[(int) config_state];
     Cmdr.print("SUCCESS: Setting button 3 offset to ");
     Cmdr.println(myInt);
     current_config.button3_offset = myInt;
@@ -349,7 +365,6 @@ bool ctrlChanHandler(Commander &Cmdr)
 {
   if (Cmdr.getInt(myInt))
   {
-    const char *color_str = color_str_array[(int) config_state];
     Cmdr.print("SUCCESS: Setting MIDI control channel to ");
     Cmdr.println(myInt);
     current_config.control_channel = myInt;
@@ -375,7 +390,8 @@ bool defaultsHandler(Commander &Cmdr)
   config_t default_config;
 
   default_config.is_enabled = true;
-  default_config.root_note=24;
+  default_config.root_note=0;
+  default_config.octave=24;
   default_config.modifier = MOD_MAJOR;
   default_config.button1_offset = 3;
   default_config.button2_offset = 5;
@@ -390,6 +406,13 @@ bool defaultsHandler(Commander &Cmdr)
   return true;
 }
 
+bool memDumpHandler(Commander &Cmdr)
+{
+  memdumpEEPROM();
+  return true;  
+}
+
+
 void printConfig(Commander &Cmdr, rot_enc_state state, bool is_last_config)
 {
   config_t print_config = loadConfigFromEEPROM(state);
@@ -403,7 +426,9 @@ void printConfig(Commander &Cmdr, rot_enc_state state, bool is_last_config)
   Cmdr.print(", \"offset3\": ");
   Cmdr.print(print_config.button3_offset);
 
-  Cmdr.print(",\"root_note\": ");
+  Cmdr.print(",\"octave\": ");
+  Cmdr.print(print_config.octave);
+  Cmdr.print(", \"root_note\": ");
   Cmdr.print(print_config.root_note);
   Cmdr.print(", \"mode\": \"");
   Cmdr.print(modifier_str_array[print_config.modifier]);

--- a/Software/PaddleFirmware/Main/ConfigConsole.h
+++ b/Software/PaddleFirmware/Main/ConfigConsole.h
@@ -95,6 +95,11 @@ bool defaultsHandler(Commander &Cmdr);
 bool rootNoteHandler(Commander &Cmdr);
 
 /**
+ * Set the octave for the current config
+ */
+bool octaveHandler(Commander &Cmdr);
+
+/**
  * Set the modifer for the current config
  */
 bool modifierHandler(Commander &Cmdr);
@@ -103,6 +108,11 @@ bool modifierHandler(Commander &Cmdr);
  * Send the heartbeat/ ID message
  */
 bool paddlePingHandler(Commander &Cmdr);
+
+/**
+ * memDump the EEPROM
+ */
+bool memDumpHandler(Commander &Cmdr);
 
 /**
  * Exit the menu and reboot
@@ -115,12 +125,14 @@ const commandList_t masterCommands[] = {
   {"enable",     colorEnableHandler,  "enable or disable this color, format is `enable=TRUE`"},
   {"color",      selectColorHandler, "select current config color, format is `color=CYAN`"},
   {"root_note",  rootNoteHandler,    "set root note of scale, format is `root=A`"},
+  {"octave",     octaveHandler,      "set root octave of scale, format is `octave=1`"},
   {"mode",       modifierHandler,    "set mode, format is `mode=MAJOR`"},
   {"offset1",    button1Handler,     "set button1 offset for this color, format is `offset1=3`"},
   {"offset2",    button2Handler,     "set button2 offset for this color, format is `offset2=5`"},
   {"offset3",    button3Handler,     "set button3 offset for this color, format is `offset3=7`"},
   {"control",    ctrlChanHandler,    "set MIDI control change idx for this color, format is `control=20`"},
   {"defaults",   defaultsHandler,    "reset all MIDI configs to default, format is `defaults`"},
+  {"memDump",    memDumpHandler,     "dump all memory in EEPROM"},
   {"paddlePing", paddlePingHandler,  "return `paddlePong`"},
   {"exit",       exitHandler,        "exit this menu and reboot, saving all settings. Format is `exit`"}
 };

--- a/Software/PaddleFirmware/Main/MIDIConstants.h
+++ b/Software/PaddleFirmware/Main/MIDIConstants.h
@@ -47,18 +47,18 @@ const int MIDI_OCTAVE_LEN  = 7;
 const int MIDI_NUM_OCTAVES = 4;
 const int MIDI_SCALE_LEN = 128;
 
-const int ROOT_NOTE_C = 24;
-const int ROOT_NOTE_CSHARP = 25;
-const int ROOT_NOTE_D = 26;
-const int ROOT_NOTE_DSHARP = 27;
-const int ROOT_NOTE_E = 28;
-const int ROOT_NOTE_F = 29;
-const int ROOT_NOTE_FSHARP = 30;
-const int ROOT_NOTE_G = 31;
-const int ROOT_NOTE_GSHARP = 32;
-const int ROOT_NOTE_A = 33;
-const int ROOT_NOTE_ASHARP = 34;
-const int ROOT_NOTE_B = 35;
+const int ROOT_NOTE_C = 0;
+const int ROOT_NOTE_CSHARP = 1;
+const int ROOT_NOTE_D = 2;
+const int ROOT_NOTE_DSHARP = 3;
+const int ROOT_NOTE_E = 4;
+const int ROOT_NOTE_F = 5;
+const int ROOT_NOTE_FSHARP = 6;
+const int ROOT_NOTE_G = 7;
+const int ROOT_NOTE_GSHARP = 8;
+const int ROOT_NOTE_A = 9;
+const int ROOT_NOTE_ASHARP = 10;
+const int ROOT_NOTE_B = 11;
 
 /* Various MIDI Scales- thanks to http://lawriecape.co.uk/theblog/index.php/archives/881 for writing these out */
 

--- a/Software/PaddleFirmware/Main/NonVolatile.cpp
+++ b/Software/PaddleFirmware/Main/NonVolatile.cpp
@@ -97,12 +97,13 @@ config_t loadConfigFromEEPROM(rot_enc_state state)
   return_config.button2_offset  = (int) EEPROM.read(base_addr + CT2_DELTA_ADDR);
   return_config.button3_offset  = (int) EEPROM.read(base_addr + CT3_DELTA_ADDR);
   return_config.root_note       = (int) EEPROM.read(base_addr + ROOT_NOTE_ADDR);
+  return_config.octave          = (int) EEPROM.read(base_addr + OCTAVE_ADDR);
   return_config.control_channel = (int) EEPROM.read(base_addr + CTRL_CHAN_ADDR);
   return_config.modifier        = (modifier_t) EEPROM.read(base_addr + SCALE_MOD_ADDR);
   if (return_config.modifier > MOD_LIMIT)
   {
     return_config.modifier = MOD_MAJOR;
-  }
+  }  
   
   return return_config;
 }
@@ -129,6 +130,15 @@ bool saveConfigToEEPROM(config_t in_config, rot_enc_state state)
     DEBUG_PRINT(": Writing root note = ");
     DEBUG_PRINTLN(in_config.root_note);
     EEPROM.write(base_addr + ROOT_NOTE_ADDR, in_config.root_note);  
+    retval = true;
+  } 
+
+  if (in_config.octave != EEPROM.read(base_addr + OCTAVE_ADDR))
+  {
+    DEBUG_PRINT(color_str);
+    DEBUG_PRINT(": Writing octave = ");
+    DEBUG_PRINTLN(in_config.octave);
+    EEPROM.write(base_addr + OCTAVE_ADDR, in_config.octave);  
     retval = true;
   } 
 
@@ -177,4 +187,36 @@ bool saveConfigToEEPROM(config_t in_config, rot_enc_state state)
     retval = true;
   }
   return retval;  
+}
+
+void memdumpEEPROM(void)
+{
+  DEBUG_PRINTLN("");
+  DEBUG_PRINTLN("");
+  DEBUG_PRINTLN("*** DUMPING EEPROM ***");
+  uint8_t value;
+
+  for (int i=0; i <= EEPROM_LIMIT; i += 0x10 )
+  {
+    DEBUG_PRINT("0x");
+    DEBUG_PRINT_HEX(i);
+    if (i<0x10)
+    {
+      DEBUG_PRINT("0");
+    }
+    DEBUG_PRINT(": ");
+    for (int j=0; j < 0x10; j++)
+    {
+      value = EEPROM.read(i+j);
+      DEBUG_PRINT(" ");
+      if (value < 0x10)
+      {
+        DEBUG_PRINT("0");
+      }
+      DEBUG_PRINT_HEX(value);      
+    }
+    DEBUG_PRINTLN("");
+  }
+  DEBUG_PRINTLN("*** DONE ***");
+  DEBUG_PRINTLN("");
 }

--- a/Software/PaddleFirmware/Main/NonVolatile.h
+++ b/Software/PaddleFirmware/Main/NonVolatile.h
@@ -28,6 +28,7 @@
 #define SCALE_MOD_ADDR    (uint8_t) 4
 #define MODE_ENABLED_ADDR (uint8_t) 5
 #define CTRL_CHAN_ADDR    (uint8_t) 6
+#define OCTAVE_ADDR       (uint8_t) 7
 
 #define EEPROM_RED_BASE_ADDR (uint8_t) 0x70
 #define EEPROM_GREEN_BASE_ADDR (uint8_t) 0x60
@@ -36,6 +37,8 @@
 #define EEPROM_PURPLE_BASE_ADDR (uint8_t) 0x30
 #define EEPROM_CYAN_BASE_ADDR (uint8_t) 0x20
 #define EEPROM_WHITE_BASE_ADDR (uint8_t) 0x10
+
+#define EEPROM_LIMIT EEPROM_RED_BASE_ADDR
 
 /**
  * Check this bit to know whether to go to config menu or regular operation
@@ -73,6 +76,7 @@ typedef struct
   uint8_t button2_offset;
   uint8_t button3_offset;
   uint8_t control_channel;
+  uint8_t octave;
 } config_t;
 
 /**
@@ -115,6 +119,11 @@ void WriteConfigMode(bool is_config_mode_enabled);
  * @return config_t Struct filled out with the values from EEPROM
  */
 config_t loadConfigFromEEPROM(rot_enc_state state);
+
+/**
+ * print all EEPROM values
+ */
+void memdumpEEPROM(void);
 
 /**
  * Compare fields of `in_config` to values in EEPROM, overwrite EEPROM where they don't match

--- a/Software/PaddleFirmware/Main/Version.h
+++ b/Software/PaddleFirmware/Main/Version.h
@@ -14,7 +14,7 @@
  * Set these to set the SW version
  */
 #define VERSION_MAJOR  (uint8_t) 1
-#define VERSION_MINOR  (uint8_t) 0
+#define VERSION_MINOR  (uint8_t) 1
 #define VERSION_BUGFIX (uint8_t) 0
 
 typedef struct {


### PR DESCRIPTION
Resolves #9

Both the client PoTConfig tool and the firmware are aware of a new "octave" config var distinct from "root_note" that will allow users more control over their instrument config.

Also add a debug `memdumpEEPROM()` command via the CLI