### PR TITLE
Modify pitchbend control code

### DIFF
--- a/Software/ClientApp/src/main/python/gui_elements/protocol/PoTProtocol.py
+++ b/Software/ClientApp/src/main/python/gui_elements/protocol/PoTProtocol.py
@@ -37,6 +37,11 @@ octaveDict = {
     "4": 60,
 }
 
+pitchbendDict = {
+    "Pitch Bend": 0,
+    "Control Code": 1,
+}
+
 
 class PoTProtocol(Protocol):
     """
@@ -57,6 +62,9 @@ class PoTProtocol(Protocol):
             "offset2": GUIParameter(),
             "offset3": GUIParameter(),
             "control": GUIParameter(),
+            "pitchbend_enable": GUIParameter(),
+            "pitchbend_is_CC": GUIParameter(),
+            "pitchbend": GUIParameter()
         }
 
         # Setup enable variable
@@ -74,6 +82,21 @@ class PoTProtocol(Protocol):
         self.parameters["octave"].permission = "RW"
         self.parameters["octave"].param_type = "U8"
         self.parameters["octave"].description = "Which octave is the root for the instrument"
+
+        self.parameters["pitchbend_enable"].name = "pitchbend Enabled"
+        self.parameters["pitchbend_enable"].permission = "RW"
+        self.parameters["pitchbend_enable"].param_type = "BOOL"
+        self.parameters["pitchbend_enable"].description = "Is pitch-bend enabled?"
+
+        self.parameters["pitchbend_is_CC"].name = "pitchbend is Control Code"
+        self.parameters["pitchbend_is_CC"].permission = "RW"
+        self.parameters["pitchbend_is_CC"].param_type = "BOOL"
+        self.parameters["pitchbend_is_CC"].description = "Does pitchbend control pitch or ControlCode"
+
+        self.parameters["pitchbend"].name = "pitchbend"
+        self.parameters["pitchbend"].permission = "RW"
+        self.parameters["pitchbend"].param_type = "U8"
+        self.parameters["pitchbend"].description = "What control code does the pitch-bend affect?"
 
         self.parameters["mode"].name = "mode"
         self.parameters["mode"].permission = "RW"
@@ -120,7 +143,8 @@ class PoTProtocol(Protocol):
         self.parameters["offset3"].value_min = 0
         self.parameters["offset3"].value_max = 60
 
-    def set_parameters(self, enable, root_note, mode, offset1, offset2, offset3, control, octave):
+    def set_parameters(self, enable, root_note, mode, offset1, offset2, offset3, control, octave,
+                       pb_enable, pb_is_cc, pb_value):
         """ use function args to set params """
         self.parameters["offset1"].variable.value = offset1
         self.parameters["offset2"].variable.value = offset2
@@ -130,3 +154,6 @@ class PoTProtocol(Protocol):
         self.parameters["root_note"].variable.value = root_note
         self.parameters["offset3"].variable.value = offset3
         self.parameters["control"].variable.value = control
+        self.parameters["pitchbend_enable"].variable.value = pb_enable
+        self.parameters["pitchbend_is_CC"].variable.value = pb_is_cc
+        self.parameters["pitchbend"].variable.value = pb_value

--- a/Software/ClientApp/src/main/python/gui_elements/tabs/ColorConfig.py
+++ b/Software/ClientApp/src/main/python/gui_elements/tabs/ColorConfig.py
@@ -3,7 +3,7 @@ import json
 from PyQt5.QtCore import pyqtSlot
 
 from pyqtsa.PyQtSA import *
-from gui_elements.protocol.PoTProtocol import modeDict, rootNoteDict, octaveDict
+from gui_elements.protocol.PoTProtocol import modeDict, rootNoteDict, octaveDict, pitchbendDict
 from serialInterpreter import CMD_EXIT, CMD_RESTORE_DEFAULTS
 
 
@@ -24,7 +24,9 @@ class ColorConfigTab(QSATab):
         self.widgets = [
             WidgetEnable(master=master, protocol=protocol, text="Color is Currently:", color=color),
             WidgetNoteAndMode(master=master, protocol=protocol, text="Scale:", color=color),
-            WidgetCCValue(master=master, protocol=protocol, text="MIDI Control Code:", color=color, serial_dict=self.MIDI_descriptions),
+            WidgetPitchBendValue(master=master, protocol=protocol, text="Pitch Bend:", color=color),
+            WidgetCCValue(master=master, protocol=protocol, text="MIDI Control Code:", color=color,
+                          serial_dict=self.MIDI_descriptions),
             WidgetOffsets(master=master, protocol=protocol, text="Offsets:", color=color),
             WidgetQuit(master=master, protocol=protocol, text="Danger Section:", color=color)
         ]
@@ -49,8 +51,41 @@ class ColorConfigTab(QSATab):
             if not isinstance(widget, WidgetEnable) and not isinstance(widget, WidgetQuit):
                 widget.setEnabled(True)
 
+    def enablePitchbendWidget(self):
+        for widget in self.widgets:
+            if isinstance(widget, WidgetPitchBendValue):
+                for subcomponent in widget.widgets:
+                    if not isinstance(subcomponent, PitchbendEnableButton):
+                        subcomponent.setEnabled(True)
+
+    def disablePitchbendWidget(self):
+        for widget in self.widgets:
+            if isinstance(widget, WidgetPitchBendValue):
+                for subcomponent in widget.widgets:
+                    if not isinstance(subcomponent, PitchbendEnableButton):
+                        subcomponent.setEnabled(False)
+
+    def enablePitchbendCC(self):
+        for widget in self.widgets:
+            if isinstance(widget, WidgetPitchBendValue):
+                for subcomponent in widget.widgets:
+                    if isinstance(subcomponent, PoTSerialEntry):
+                        subcomponent.setEnabled(True)
+
+    def disablePitchbendCC(self):
+        for widget in self.widgets:
+            if isinstance(widget, WidgetPitchBendValue):
+                for subcomponent in widget.widgets:
+                    if isinstance(subcomponent, PoTSerialEntry):
+                        subcomponent.setEnabled(False)
+
     def fullReload(self):
-        self.widgets[0].widgets[0].reload()
+        for widget in self.widgets:
+            for subcomponent in widget.widgets:
+                try:
+                    subcomponent.reload()
+                except AttributeError:
+                    pass
 
 
 class PoTComboBox(QSAVariableFrame):
@@ -74,11 +109,19 @@ class PoTComboBox(QSAVariableFrame):
         self.layout.addWidget(self.combo_box, 0, 1, 1, 4)
         self.combo_box.setFixedWidth(90)
 
+    def reload(self):
+        try:
+            self.combo_box.setCurrentIndex(self.values.index(self.parameter.variable.value))
+        except ValueError:
+            pass
+
     def onChanged(self, text):
         self.combo_box.adjustSize()
         self.master.si.send_serial_command(cmd="color", argument=self.color)
         my_argument = self.values[self.keys.index(text)]
         self.master.si.send_serial_command(cmd=self.parameter.name, argument=my_argument)
+        self.parameter.variable.value = my_argument
+        self.combo_box.setCurrentIndex(self.values.index(self.parameter.variable.value))
 
     def updateValue(self, value=None):
         self.combo_box.setCurrentIndex(self.parameter.variable.value)
@@ -190,6 +233,10 @@ class PoTControlCodeEntry(QSAEntry):
         self.parameter.variable.value = int(self.spinbox_set.value())
         self.helpText.updateValue(self.configDict[str(self.parameter.variable.value)])
 
+    def reload(self):
+        self.helpText.updateValue(self.configDict[str(self.parameter.variable.value)])
+
+
     def onEditingFinished(self):
         self.parameter.variable.value = int(self.spinbox_set.value())
         self.master.si.send_serial_command(cmd="color", argument=self.color)
@@ -291,6 +338,117 @@ class WidgetOffsets(QSAWidgetCluster):
                              PoTSerialEntry(master=master, text="Offset2:", parameter=protocol.parameters["offset2"],
                                             color=color),
                              PoTSerialEntry(master=master, text="Offset3:", parameter=protocol.parameters["offset3"],
+                                            color=color),
+                         ],
+                         )
+
+
+class PitchbendEnableButton(QSAToggleButton):
+    def __init__(self, master=None, text=None, parameter=None, color=None):
+        super().__init__(master=master, text=text, parameter=parameter)
+        self.master = master
+        self.color = color
+        self.parameter = parameter
+
+    def reload(self):
+        if 1 == self.state.value:
+            self.button.setStyleSheet(widgetStyle_toggleButtonEnable)
+            self.buttonText = self.onText
+            for page in self.master.tabs.pages:
+                page.enablePitchbendWidget()
+        else:
+            self.button.setStyleSheet(widgetStyle_toggleButtonDisable)
+            self.buttonText = self.offText
+            for page in self.master.tabs.pages:
+                page.disablePitchbendWidget()
+
+    def onClick(self):
+        if self.master is not None:
+
+            if 1 == self.state.value:
+                self.button.setStyleSheet(widgetStyle_toggleButtonEnable)
+                self.buttonText = self.onText
+                for page in self.master.tabs.pages:
+                    page.disablePitchbendWidget()
+                self.master.si.send_serial_command(cmd="color", argument=self.color)
+                self.master.si.send_serial_command(cmd="pitchbend", argument=255)
+            else:
+                self.button.setStyleSheet(widgetStyle_toggleButtonDisable)
+                self.buttonText = self.offText
+                for page in self.master.tabs.pages:
+                    page.enablePitchbendWidget()
+
+
+class PitchbendComboBox(QSAVariableFrame):
+    def __init__(self, master=None, text=None, parameter=None, enabled_parameter=None, color=None, keys=[], values=[]):
+        super().__init__(master=master, parameter=parameter)
+        self.master = master
+        self.text = text
+        self.parameter = parameter
+        self.enabledParameter = enabled_parameter
+        self.color = color
+        self.values = list(values)
+        self.keys = list(keys)
+
+        self.combo_box = QComboBox()
+        self.combo_box.activated[str].connect(self.onChanged)
+        for key in keys:
+            self.combo_box.addItem(key)
+
+        self.combo_box.setStyleSheet(widgetStyle_spinboxActual)
+        self.parameter.variable.bind_to(self.updateValue)
+
+        self.layout.addWidget(self.combo_box, 0, 1, 1, 4)
+        self.combo_box.setFixedWidth(90)
+
+    def reload(self):
+        if self.combo_box.currentIndex() == 0:
+            for page in self.master.tabs.pages:
+                page.disablePitchbendCC()
+        else:
+            if self.enabledParameter.variable.value:
+                for page in self.master.tabs.pages:
+                    page.enablePitchbendCC()
+
+    def onChanged(self, text):
+        self.combo_box.adjustSize()
+        if text == "Pitch Bend":
+            self.master.si.send_serial_command(cmd="color", argument=self.color)
+            self.master.si.send_serial_command(cmd="pitchbend", argument=0xE0)
+            for page in self.master.tabs.pages:
+                page.disablePitchbendCC()
+
+        else:
+            if self.enabledParameter.variable.value:
+                for page in self.master.tabs.pages:
+                    page.enablePitchbendCC()
+
+    def updateValue(self, value=None):
+        self.combo_box.setCurrentIndex(self.parameter.variable.value)
+
+
+class WidgetPitchBendValue(QSAWidgetCluster):
+    def __init__(self, master=None, text=None, protocol=None, color=None):
+        super().__init__(master=master,
+                         text=text,
+                         widgets=[
+                             PitchbendEnableButton(
+                                 master=master,
+                                 text="Enable:",
+                                 parameter=protocol.parameters["pitchbend_enable"],
+                                 color=color
+                             ),
+                             PitchbendComboBox(
+                                 master=master,
+                                 text="Type:",
+                                 parameter=protocol.parameters["pitchbend_is_CC"],
+                                 enabled_parameter=protocol.parameters["pitchbend_enable"],
+                                 keys=pitchbendDict.keys(),
+                                 values=pitchbendDict.values(),
+                                 color=color
+                             ),
+                             PoTSerialEntry(master=master, text="CC_Idx:",
+                                            parameter=protocol.parameters["pitchbend"],
                                             color=color),
                          ],
                          )

--- a/Software/ClientApp/src/main/python/gui_elements/tabs/ColorConfig.py
+++ b/Software/ClientApp/src/main/python/gui_elements/tabs/ColorConfig.py
@@ -344,11 +344,12 @@ class WidgetOffsets(QSAWidgetCluster):
 
 
 class PitchbendEnableButton(QSAToggleButton):
-    def __init__(self, master=None, text=None, parameter=None, color=None):
+    def __init__(self, master=None, text=None, parameter=None, enabled_parameter=None, color=None):
         super().__init__(master=master, text=text, parameter=parameter)
         self.master = master
         self.color = color
         self.parameter = parameter
+        self.enabledParameter = enabled_parameter
 
     def reload(self):
         if 1 == self.state.value:
@@ -372,6 +373,7 @@ class PitchbendEnableButton(QSAToggleButton):
                     page.disablePitchbendWidget()
                 self.master.si.send_serial_command(cmd="color", argument=self.color)
                 self.master.si.send_serial_command(cmd="pitchbend", argument=255)
+                self.enabledParameter.variable.value = 255
             else:
                 self.button.setStyleSheet(widgetStyle_toggleButtonDisable)
                 self.buttonText = self.offText
@@ -406,7 +408,7 @@ class PitchbendComboBox(QSAVariableFrame):
             for page in self.master.tabs.pages:
                 page.disablePitchbendCC()
         else:
-            if self.enabledParameter.variable.value:
+            if self.enabledParameter.variable.value < 128:
                 for page in self.master.tabs.pages:
                     page.enablePitchbendCC()
 
@@ -415,6 +417,7 @@ class PitchbendComboBox(QSAVariableFrame):
         if text == "Pitch Bend":
             self.master.si.send_serial_command(cmd="color", argument=self.color)
             self.master.si.send_serial_command(cmd="pitchbend", argument=0xE0)
+            self.enabledParameter.variable.value = 224
             for page in self.master.tabs.pages:
                 page.disablePitchbendCC()
 
@@ -436,13 +439,14 @@ class WidgetPitchBendValue(QSAWidgetCluster):
                                  master=master,
                                  text="Enable:",
                                  parameter=protocol.parameters["pitchbend_enable"],
+                                 enabled_parameter=protocol.parameters["pitchbend"],
                                  color=color
                              ),
                              PitchbendComboBox(
                                  master=master,
                                  text="Type:",
                                  parameter=protocol.parameters["pitchbend_is_CC"],
-                                 enabled_parameter=protocol.parameters["pitchbend_enable"],
+                                 enabled_parameter=protocol.parameters["pitchbend"],
                                  keys=pitchbendDict.keys(),
                                  values=pitchbendDict.values(),
                                  color=color

--- a/Software/ClientApp/src/main/python/gui_elements/tabs/ColorConfig.py
+++ b/Software/ClientApp/src/main/python/gui_elements/tabs/ColorConfig.py
@@ -24,9 +24,9 @@ class ColorConfigTab(QSATab):
         self.widgets = [
             WidgetEnable(master=master, protocol=protocol, text="Color is Currently:", color=color),
             WidgetNoteAndMode(master=master, protocol=protocol, text="Scale:", color=color),
-            WidgetPitchBendValue(master=master, protocol=protocol, text="Pitch Bend:", color=color),
             WidgetCCValue(master=master, protocol=protocol, text="MIDI Control Code:", color=color,
                           serial_dict=self.MIDI_descriptions),
+            WidgetPitchBendValue(master=master, protocol=protocol, text="Pitch Bend:", color=color),
             WidgetOffsets(master=master, protocol=protocol, text="Offsets:", color=color),
             WidgetQuit(master=master, protocol=protocol, text="Danger Section:", color=color)
         ]

--- a/Software/ClientApp/src/main/python/serialInterpreter.py
+++ b/Software/ClientApp/src/main/python/serialInterpreter.py
@@ -114,12 +114,17 @@ class SerialInterpreter:
         if not response_str:
             raise RuntimeError('Got no response from paddle')
 
+        print(response_str)
         result_obj = json.loads(response_str)
         for key in result_obj[STR_ALL_CONFIGS].keys():
             this_config = result_obj[STR_ALL_CONFIGS][key]
             print("{0}: {1}".format(key, this_config))
+
             config_dict[key].set_parameters(
                 control=this_config["control"],
+                pb_is_cc=(int(this_config["pitchbend"]) != 0xE0),
+                pb_enable=(int(this_config["pitchbend"]) < 128 or int(this_config["pitchbend"] == 0xE0)),
+                pb_value=this_config["pitchbend"],
                 offset1=this_config["offset1"],
                 offset2=this_config["offset2"],
                 offset3=this_config["offset3"],

--- a/Software/PaddleFirmware/Main/ConfigConsole.cpp
+++ b/Software/PaddleFirmware/Main/ConfigConsole.cpp
@@ -402,8 +402,9 @@ bool defaultsHandler(Commander &Cmdr)
   config_t default_config;
 
   default_config.is_enabled = true;
-  default_config.root_note=0;
-  default_config.octave=24;
+  default_config.root_note = 0;
+  default_config.octave = 24;
+  default_config.pitchbend_channel = MIDI_CTRL_CHG_PITCHBEND;
   default_config.modifier = MOD_MAJOR;
   default_config.button1_offset = 3;
   default_config.button2_offset = 5;

--- a/Software/PaddleFirmware/Main/ConfigConsole.cpp
+++ b/Software/PaddleFirmware/Main/ConfigConsole.cpp
@@ -373,6 +373,18 @@ bool ctrlChanHandler(Commander &Cmdr)
   return true;
 }
 
+bool pbChanHandler(Commander &Cmdr)
+{
+  if (Cmdr.getInt(myInt))
+  {
+    Cmdr.print("SUCCESS: Setting Pitchbend control channel to ");
+    Cmdr.println(myInt);
+    current_config.pitchbend_channel = myInt;
+    saveConfigToEEPROM(current_config, config_state);
+  }
+  return true;
+}
+
 bool exitHandler(Commander &Cmdr)
 {
   Cmdr.println("Saving settings!");
@@ -435,5 +447,7 @@ void printConfig(Commander &Cmdr, rot_enc_state state, bool is_last_config)
   
   Cmdr.print("\", \"control\": ");
   Cmdr.print(print_config.control_channel);  
+  Cmdr.print("\", \"pitchbend\": ");
+  Cmdr.print(print_config.pitchbend_channel);
   Cmdr.print((is_last_config) ? "}" : "},");
 }

--- a/Software/PaddleFirmware/Main/ConfigConsole.cpp
+++ b/Software/PaddleFirmware/Main/ConfigConsole.cpp
@@ -448,7 +448,7 @@ void printConfig(Commander &Cmdr, rot_enc_state state, bool is_last_config)
   
   Cmdr.print("\", \"control\": ");
   Cmdr.print(print_config.control_channel);  
-  Cmdr.print("\", \"pitchbend\": ");
+  Cmdr.print(", \"pitchbend\": ");
   Cmdr.print(print_config.pitchbend_channel);
   Cmdr.print((is_last_config) ? "}" : "},");
 }

--- a/Software/PaddleFirmware/Main/ConfigConsole.h
+++ b/Software/PaddleFirmware/Main/ConfigConsole.h
@@ -55,22 +55,22 @@ bool infoHandler(Commander &Cmdr);
 bool printConfigHandler(Commander &Cmdr);
 
 /**
- * Set the MIDI control channel
+ * Set the MIDI control channel for the current config
  */
 bool ctrlChanHandler(Commander &Cmdr);
 
 /**
- * Set the button1 delta
- */
+ * Set the button1 delta for the current config
+ */ 
 bool button1Handler(Commander &Cmdr);
 
 /**
- * Set the button2 delta
+ * Set the button2 delta for the current config
  */
 bool button2Handler(Commander &Cmdr);
 
 /**
- * Set the button3 delta
+ * Set the button3 delta for the current config
  */
 bool button3Handler(Commander &Cmdr);
 
@@ -105,6 +105,11 @@ bool octaveHandler(Commander &Cmdr);
 bool modifierHandler(Commander &Cmdr);
 
 /**
+ * Set the channel controlled by pitchbend for the current config
+ */
+bool pbChanHandler(Commander &Cmdr);
+
+/**
  * Send the heartbeat/ ID message
  */
 bool paddlePingHandler(Commander &Cmdr);
@@ -131,6 +136,7 @@ const commandList_t masterCommands[] = {
   {"offset2",    button2Handler,     "set button2 offset for this color, format is `offset2=5`"},
   {"offset3",    button3Handler,     "set button3 offset for this color, format is `offset3=7`"},
   {"control",    ctrlChanHandler,    "set MIDI control change idx for this color, format is `control=20`"},
+  {"pitchbend",  pbChanHandler,      "set Pitchbend control change idx for this color, format is `pitchbend=20`"},
   {"defaults",   defaultsHandler,    "reset all MIDI configs to default, format is `defaults`"},
   {"memDump",    memDumpHandler,     "dump all memory in EEPROM"},
   {"paddlePing", paddlePingHandler,  "return `paddlePong`"},

--- a/Software/PaddleFirmware/Main/MIDIConstants.h
+++ b/Software/PaddleFirmware/Main/MIDIConstants.h
@@ -41,6 +41,9 @@ const int MIDI_CTRL_CHG_EXPRESSION = 0x0B;
 const int MIDI_CTRL_CHG_EFFECT_1   = 0x0C;
 const int MIDI_CTRL_CHG_EFFECT_2   = 0x0D;
 const int MIDI_CTRL_CHG_LEGATO_FSW = 0x44;
+const int MIDI_CTRL_CHG_PITCHBEND  = 0xE0;
+const int MIDI_CTRL_CHG_MAX        = 0x7F;
+const int MIDI_CTRL_CHG_INVAL      = 0xFF;
 
 const int FRET_LEN = 29;
 const int MIDI_OCTAVE_LEN  = 7;

--- a/Software/PaddleFirmware/Main/Main.ino
+++ b/Software/PaddleFirmware/Main/Main.ino
@@ -226,8 +226,7 @@ void loop()
         rotEnc.write(constrained_enc_reading);
       }
     }
-    
-    
+       
     if (constrained_enc_reading != prev_enc_reading)
     {
       usbMIDI.sendControlChange(running_config.control_channel, constrained_enc_reading, MIDI_CHANNEL_2);
@@ -278,7 +277,23 @@ void loop()
     curr_bend_val = SCALED_PITCH_BEND(range_in_cm);
     if (curr_bend_val!= prev_bend_val && abs(curr_bend_val- prev_bend_val) < MAX_PITCH_BEND_DELTA)
     {
-      usbMIDI.sendPitchBend(curr_bend_val, MIDI_CHANNEL_2);
+      if (running_config.pitchbend_channel == MIDI_CTRL_CHG_PITCHBEND)
+      {
+        usbMIDI.sendPitchBend(curr_bend_val, MIDI_CHANNEL_2);
+      }
+      else if (running_config.pitchbend_channel < MIDI_CTRL_CHG_MAX)
+      {        
+        usbMIDI.sendControlChange(running_config.pitchbend_channel, ONEBYTE_SCALED_PITCH_BEND(range_in_cm), MIDI_CHANNEL_2);
+      }
+      else if (running_config.pitchbend_channel == MIDI_CTRL_CHG_INVAL)
+      {
+        // don't send pitchbend            
+      }
+      else // any invalid Control Change input value should be ignored
+      {
+        // also don't send pitchbend                    
+      }
+      
       prev_bend_val = curr_bend_val;
     }
   

--- a/Software/PaddleFirmware/Main/NonVolatile.cpp
+++ b/Software/PaddleFirmware/Main/NonVolatile.cpp
@@ -92,14 +92,15 @@ config_t loadConfigFromEEPROM(rot_enc_state state)
   int base_addr = config_addr_array[(int) state];
 
   /* fill out config_t */
-  return_config.is_enabled      = (bool) (0 == EEPROM.read(base_addr + MODE_ENABLED_ADDR)) ? false : true;
-  return_config.button1_offset  = (int) EEPROM.read(base_addr + CT1_DELTA_ADDR);
-  return_config.button2_offset  = (int) EEPROM.read(base_addr + CT2_DELTA_ADDR);
-  return_config.button3_offset  = (int) EEPROM.read(base_addr + CT3_DELTA_ADDR);
-  return_config.root_note       = (int) EEPROM.read(base_addr + ROOT_NOTE_ADDR);
-  return_config.octave          = (int) EEPROM.read(base_addr + OCTAVE_ADDR);
-  return_config.control_channel = (int) EEPROM.read(base_addr + CTRL_CHAN_ADDR);
-  return_config.modifier        = (modifier_t) EEPROM.read(base_addr + SCALE_MOD_ADDR);
+  return_config.is_enabled        = (bool) (0 == EEPROM.read(base_addr + MODE_ENABLED_ADDR)) ? false : true;
+  return_config.button1_offset    = (int) EEPROM.read(base_addr + CT1_DELTA_ADDR);
+  return_config.button2_offset    = (int) EEPROM.read(base_addr + CT2_DELTA_ADDR);
+  return_config.button3_offset    = (int) EEPROM.read(base_addr + CT3_DELTA_ADDR);
+  return_config.root_note         = (int) EEPROM.read(base_addr + ROOT_NOTE_ADDR);
+  return_config.octave            = (int) EEPROM.read(base_addr + OCTAVE_ADDR);
+  return_config.control_channel   = (int) EEPROM.read(base_addr + CTRL_CHAN_ADDR);
+  return_config.pitchbend_channel = (int) EEPROM.read(base_addr + PB_CHAN_ADDR);
+  return_config.modifier          = (modifier_t) EEPROM.read(base_addr + SCALE_MOD_ADDR);
   if (return_config.modifier > MOD_LIMIT)
   {
     return_config.modifier = MOD_MAJOR;
@@ -186,6 +187,16 @@ bool saveConfigToEEPROM(config_t in_config, rot_enc_state state)
     EEPROM.write(base_addr + CTRL_CHAN_ADDR, (int) in_config.control_channel);  
     retval = true;
   }
+
+  if (in_config.pitchbend_channel != EEPROM.read(base_addr + PB_CHAN_ADDR))
+  {
+    DEBUG_PRINT(color_str);
+    DEBUG_PRINT(": Writing Pitchbend control channel = ");
+    DEBUG_PRINTLN(in_config.pitchbend_channel);
+    EEPROM.write(base_addr + PB_CHAN_ADDR, (int) in_config.pitchbend_channel);  
+    retval = true;
+  }
+  
   return retval;  
 }
 

--- a/Software/PaddleFirmware/Main/NonVolatile.h
+++ b/Software/PaddleFirmware/Main/NonVolatile.h
@@ -29,6 +29,7 @@
 #define MODE_ENABLED_ADDR (uint8_t) 5
 #define CTRL_CHAN_ADDR    (uint8_t) 6
 #define OCTAVE_ADDR       (uint8_t) 7
+#define PB_CHAN_ADDR      (uint8_t) 8
 
 #define EEPROM_RED_BASE_ADDR (uint8_t) 0x70
 #define EEPROM_GREEN_BASE_ADDR (uint8_t) 0x60
@@ -77,6 +78,7 @@ typedef struct
   uint8_t button3_offset;
   uint8_t control_channel;
   uint8_t octave;
+  uint8_t pitchbend_channel;
 } config_t;
 
 /**

--- a/Software/PaddleFirmware/Main/Ultrasonic.h
+++ b/Software/PaddleFirmware/Main/Ultrasonic.h
@@ -28,7 +28,7 @@
 /**
  * If using pitch bend for another MIDI control code, the range is only 0-127
  */
-#define ONEBYTE_SCALED_PITCH_BEND(x) (int) (pow(2,7) * x  / PITCH_BEND_MAX_CM)  // Do not adjust!
+#define ONEBYTE_SCALED_PITCH_BEND(x) (int) (pow(2,7) * (PITCH_BEND_MAX_CM - x)  / PITCH_BEND_MAX_CM)  // Do not adjust!
 
 
 #endif // __ULTRASONIC_H__

--- a/Software/PaddleFirmware/Main/Ultrasonic.h
+++ b/Software/PaddleFirmware/Main/Ultrasonic.h
@@ -25,4 +25,10 @@
  */
 #define SCALED_PITCH_BEND(x) (int) (pow(2,12) * x  / PITCH_BEND_MAX_CM) - pow(2,12)  // Do not adjust!
 
+/**
+ * If using pitch bend for another MIDI control code, the range is only 0-127
+ */
+#define ONEBYTE_SCALED_PITCH_BEND(x) (int) (pow(2,7) * x  / PITCH_BEND_MAX_CM)  // Do not adjust!
+
+
 #endif // __ULTRASONIC_H__

--- a/Software/PaddleFirmware/Main/Version.h
+++ b/Software/PaddleFirmware/Main/Version.h
@@ -14,7 +14,7 @@
  * Set these to set the SW version
  */
 #define VERSION_MAJOR  (uint8_t) 1
-#define VERSION_MINOR  (uint8_t) 1
+#define VERSION_MINOR  (uint8_t) 2
 #define VERSION_BUGFIX (uint8_t) 0
 
 typedef struct {


### PR DESCRIPTION
Resolves #28 
Resolves #29 

New options in the GUI and the EEPROM allow the user to set the pitch-bend in 3 ways.. It can now be:
* Disabled fully
* Enabled in its default "pitch-bend" setting
* Used like the "pitch-bend" setting to control another MIDI control code

Additionally, added a slight improvement of how the GUI displays loaded status in the combo boxes